### PR TITLE
feat: manage Herdr session restore integrations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -425,6 +425,9 @@
             herdr
             herdr-agent-skill
             herdr-agent-plugin
+            herdr-claude-integration
+            herdr-codex-integration
+            herdr-pi-integration
             herdr-codex-marketplace
             ;
         }
@@ -466,7 +469,7 @@
               pkgs.runCommand "nix-custom-settings-tests" { } "touch $out"
             else
               throw "nix custom settings tests failed: ${builtins.toJSON failures}";
-          # merge.py のテスト。ビルド時実行なので build-linux ジョブが強制する
+          # Codex Python helpers のテスト。ビルド時実行なので build-linux ジョブが強制する
           merge-py-tests =
             pkgs.runCommand "merge-py-tests"
               {
@@ -480,7 +483,9 @@
               ''
                 cp ${./nix/modules/home/programs/codex/merge.py} merge.py
                 cp ${./nix/modules/home/programs/codex/test_merge.py} test_merge.py
-                pytest -q test_merge.py
+                cp ${./nix/modules/home/programs/codex/generate_herdr_hook_state.py} generate_herdr_hook_state.py
+                cp ${./nix/modules/home/programs/codex/test_generate_herdr_hook_state.py} test_generate_herdr_hook_state.py
+                pytest -q test_merge.py test_generate_herdr_hook_state.py
                 touch $out
               '';
         }

--- a/nix/modules/home/programs/claude.nix
+++ b/nix/modules/home/programs/claude.nix
@@ -8,6 +8,15 @@
 let
   inherit (config.my) dotfilesDir;
 
+  claudeHome = "${config.home.homeDirectory}/.claude";
+  herdrClaudeIntegration = pkgs.herdr-claude-integration;
+  herdrHookPath = "${claudeHome}/hooks/herdr-agent-state.sh";
+  herdrHookPathEnv = lib.makeBinPath [
+    pkgs.coreutils
+    pkgs.python3
+  ];
+  herdrHookCommand = "${pkgs.coreutils}/bin/env PATH=${herdrHookPathEnv} ${pkgs.bash}/bin/bash ${lib.escapeShellArg herdrHookPath} session";
+
   # HM 側 (programs.claude-code) も plugins 用に symlinkJoin で包むため、
   # wrapper は絶対パスで実体を参照して多段合成できるようにする。
   claudeCodePackage = pkgs.symlinkJoin {
@@ -41,6 +50,17 @@ let
     }
   );
 
+  herdrSettingsFile =
+    pkgs.runCommand "claude-herdr-settings.json"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+      }
+      ''
+        jq --arg command ${lib.escapeShellArg herdrHookCommand} '
+          .hooks.SessionStart |= map(.hooks |= map(.command = $command))
+        ' ${herdrClaudeIntegration}/settings.json > $out
+      '';
+
   # hcom 分は生成物 (overlay が hcom 実行で生成) から取り、手書きで二重管理しない。
   mergedSettingsRaw =
     pkgs.runCommand "claude-settings.json"
@@ -49,11 +69,16 @@ let
       }
       ''
         jq -s '
+          def merge_hooks($first; $second; $third):
+            reduce ((($first | keys_unsorted) + ($second | keys_unsorted) + ($third | keys_unsorted)) | unique[]) as $key
+              ({}; .[$key] = (($first[$key] // []) + ($second[$key] // []) + ($third[$key] // [])));
+
           .[0] as $base | .[1] as $hcom |
+          .[2] as $herdr |
           $base
           | .permissions.allow += $hcom.permissions.allow
-          | .hooks = ($hcom.hooks + { PreToolUse: (($hcom.hooks.PreToolUse // []) + $base.hooks.PreToolUse) })
-        ' ${baseSettingsFile} ${pkgs.hcom-claude-hooks} > $out
+          | .hooks = merge_hooks(($hcom.hooks // {}); ($base.hooks // {}); ($herdr.hooks // {}))
+        ' ${baseSettingsFile} ${pkgs.hcom-claude-hooks} ${herdrSettingsFile} > $out
       '';
 
   mergedSettingsFile = settingsValidator.validate "claude-settings.json" mergedSettingsRaw;
@@ -79,6 +104,16 @@ in
     config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/claude/rules";
   home.file.".claude/output-styles".source =
     config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/claude/output-styles";
-  home.file.".claude/hooks".source =
-    config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/claude/hooks";
+  home.file.".claude/hooks/.gitkeep".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/claude/hooks/.gitkeep";
+  home.file.".claude/hooks/herdr-agent-state.sh".source =
+    "${herdrClaudeIntegration}/hooks/herdr-agent-state.sh";
+
+  home.activation.claudeHooksDirectoryMigration = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
+    legacy_hooks="${claudeHome}/hooks"
+    legacy_target="${dotfilesDir}/claude/hooks"
+    if [ -L "$legacy_hooks" ] && [ "$(${pkgs.coreutils}/bin/readlink -f "$legacy_hooks")" = "$legacy_target" ]; then
+      run ${pkgs.coreutils}/bin/rm "$legacy_hooks"
+    fi
+  '';
 }

--- a/nix/modules/home/programs/codex/default.nix
+++ b/nix/modules/home/programs/codex/default.nix
@@ -8,6 +8,7 @@ let
   # 生成は overlay (hcom+codex を実行) に任せ参照のみ — Codex の内部仕様 (hash
   # アルゴリズム等) をこちらで再実装しないため。
   hcomCodex = pkgs.hcom-codex-hooks;
+  herdrCodexIntegration = pkgs.herdr-codex-integration;
 
   codexHome = "${config.home.homeDirectory}/.codex";
   configPath = "${codexHome}/config.toml";
@@ -17,6 +18,12 @@ let
   jsonFormat = pkgs.formats.json { };
   herdrSkillPath = "${codexHome}/skills/herdr/SKILL.md";
   enableHerdrSkillOverride = "skills.config=[{path=${builtins.toJSON herdrSkillPath},enabled=true}]";
+  herdrHookPath = "${codexHome}/herdr-agent-state.sh";
+  herdrHookPathEnv = lib.makeBinPath [
+    pkgs.coreutils
+    pkgs.python3
+  ];
+  herdrHookCommand = "${pkgs.coreutils}/bin/env PATH=${herdrHookPathEnv} ${pkgs.bash}/bin/bash ${lib.escapeShellArg herdrHookPath} session";
 
   codex = pkgs.writeShellApplication {
     name = "codex";
@@ -51,14 +58,60 @@ let
         ' ${hcomCodex}/hooks-state.json > $out
       '';
 
-  # merge.py には単一 payload を渡すため、Nix 管理設定と hcom 生成設定をここで合成する。
+  hooksJson =
+    pkgs.runCommand "codex-hooks.json"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+      }
+      ''
+        jq --arg command ${lib.escapeShellArg herdrHookCommand} '
+          .hooks.SessionStart = ((.hooks.SessionStart // []) + [
+            {
+              hooks: [
+                {
+                  command: $command,
+                  timeout: 10,
+                  type: "command"
+                }
+              ]
+            }
+          ])
+        ' ${hcomCodex}/hooks.json > $out
+      '';
+
+  herdrHooksStatePayloadJson =
+    pkgs.runCommand "codex-herdr-hooks-state-payload.json"
+      {
+        nativeBuildInputs = [ pkgs.python3 ];
+      }
+      ''
+        home="$NIX_BUILD_TOP/home"
+        mkdir -p "$home/.codex"
+        cp ${hooksJson} "$home/.codex/hooks.json"
+        printf '[features]\nhooks = true\n' > "$home/.codex/config.toml"
+
+        export HOME="$home"
+        export XDG_CONFIG_HOME="$home/.config"
+
+        ${pkgs.python3}/bin/python3 ${./generate_herdr_hook_state.py} \
+          --codex-bin ${lib.escapeShellArg "${pkgs.codex}/bin/codex"} \
+          --hook-command ${lib.escapeShellArg herdrHookCommand} \
+          --hooks-json-path ${lib.escapeShellArg hooksJsonPath} \
+          > "$out"
+      '';
+
+  # merge.py には単一 payload を渡すため、Nix 管理設定と hook 生成設定をここで合成する。
   mergePayloadJson =
     pkgs.runCommand "codex-config-merge.json"
       {
         nativeBuildInputs = [ pkgs.jq ];
       }
       ''
-        jq -s '.[0] * .[1]' ${baseMergePayloadJson} ${hcomHooksPayloadJson} > $out
+        jq -s '.[0] * .[1] * .[2]' \
+          ${baseMergePayloadJson} \
+          ${hcomHooksPayloadJson} \
+          ${herdrHooksStatePayloadJson} \
+          > $out
       '';
 
   # 検証に使う schema は、実際に導入する Codex CLI と同じ source tag から取り出す。
@@ -74,7 +127,8 @@ in
   home.packages = [ codex ];
 
   # Codex は読むだけなので read-only symlink で良い。
-  home.file.".codex/hooks.json".source = "${hcomCodex}/hooks.json";
+  home.file.".codex/hooks.json".source = hooksJson;
+  home.file.".codex/herdr-agent-state.sh".source = "${herdrCodexIntegration}/herdr-agent-state.sh";
 
   # Herdr の Codex plugin enable は SessionFlags (`-c`) で反転できないため、
   # Codex では通常 skill として配置し、skills.config だけを wrapper から反転する。
@@ -88,10 +142,10 @@ in
   # で一意にするのは固定名だと並行 switch が同じ候補を共有し TOCTOU になるため。
   # サブシェル + set -e + trap は、後始末を他フラグメントへ漏らさず、検証失敗時に
   # 本番へ mv させないため。
-  home.activation.codexHcomHooks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.codexHooksConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     (
       set -e
-      candidate=$(${pkgs.coreutils}/bin/mktemp "${configPath}.hcom-XXXXXX")
+      candidate=$(${pkgs.coreutils}/bin/mktemp "${configPath}.hooks-XXXXXX")
       trap '${pkgs.coreutils}/bin/rm -f "$candidate"' EXIT
       run ${pythonWithTomlkit}/bin/python3 ${./merge.py} \
         "${configPath}" "${mergePayloadJson}" "$candidate"

--- a/nix/modules/home/programs/codex/generate_herdr_hook_state.py
+++ b/nix/modules/home/programs/codex/generate_herdr_hook_state.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Generate Codex hook trust state for the Herdr SessionStart hook.
+
+Codex computes hook trust hashes from its normalized hook identity. Keep that
+logic in Codex by asking the app-server for hooks/list and re-key only the
+absolute hooks.json path for the target home directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def _send(proc: subprocess.Popen[str], message: dict[str, Any]) -> None:
+    if proc.stdin is None:
+        raise RuntimeError("codex app-server stdin is unavailable")
+    proc.stdin.write(json.dumps(message) + "\n")
+    proc.stdin.flush()
+
+
+def read_response(
+    proc: subprocess.Popen[str], request_id: int, timeout_sec: float = 10.0
+) -> dict[str, Any]:
+    if proc.stdout is None:
+        raise RuntimeError("codex app-server stdout is unavailable")
+
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        remaining = max(0.0, deadline - time.monotonic())
+        readable, _, _ = select.select([proc.stdout], [], [], remaining)
+        if not readable:
+            break
+
+        line = proc.stdout.readline()
+        if not line:
+            break
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if value.get("id") == request_id:
+            if "error" in value:
+                raise RuntimeError(value["error"])
+            return value
+
+    raise RuntimeError(f"timed out waiting for codex app-server response {request_id}")
+
+
+def fetch_hooks_list(codex_bin: str, cwd: str) -> dict[str, Any]:
+    proc = subprocess.Popen(
+        [codex_bin, "app-server", "--listen", "stdio://"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        _send(
+            proc,
+            {
+                "method": "initialize",
+                "id": 1,
+                "params": {
+                    "clientInfo": {
+                        "name": "dotfiles",
+                        "title": "dotfiles",
+                        "version": "0",
+                    },
+                    "capabilities": {"experimentalApi": True},
+                },
+            },
+        )
+        read_response(proc, 1)
+
+        _send(proc, {"method": "initialized", "params": {}})
+        _send(
+            proc,
+            {
+                "method": "hooks/list",
+                "id": 2,
+                "params": {"cwds": [cwd]},
+            },
+        )
+        return read_response(proc, 2)
+    except Exception as exc:
+        stderr = ""
+        if proc.stderr is not None:
+            try:
+                proc.kill()
+                proc.wait(timeout=5)
+                stderr = proc.stderr.read()
+            except Exception:
+                pass
+        if stderr:
+            raise RuntimeError(f"{exc}; stderr={stderr}") from exc
+        raise
+    finally:
+        if proc.stdin is not None:
+            try:
+                proc.stdin.close()
+            except Exception:
+                pass
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait()
+
+
+def build_payload(
+    hooks_list_response: dict[str, Any], hook_command: str, hooks_json_path: str
+) -> dict[str, Any]:
+    hooks = [
+        hook
+        for entry in hooks_list_response["result"]["data"]
+        for hook in entry["hooks"]
+        if hook.get("eventName") == "sessionStart"
+        and hook.get("command") == hook_command
+    ]
+    if len(hooks) != 1:
+        raise RuntimeError(f"expected exactly one Herdr Codex hook, found {len(hooks)}")
+
+    hook = hooks[0]
+    key_parts = hook["key"].split(":")
+    if len(key_parts) < 4:
+        raise RuntimeError(f"unexpected Codex hook key: {hook['key']}")
+
+    state_suffix = ":".join(key_parts[-3:])
+    state_key = f"{hooks_json_path}:{state_suffix}"
+    return {
+        "hooks": {
+            "state": {
+                state_key: {
+                    "trusted_hash": hook["currentHash"],
+                    "enabled": True,
+                }
+            }
+        }
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--codex-bin", required=True)
+    parser.add_argument("--hook-command", required=True)
+    parser.add_argument("--hooks-json-path", required=True)
+    parser.add_argument("--cwd", default=os.getcwd())
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    hooks_list_response = fetch_hooks_list(args.codex_bin, args.cwd)
+    payload = build_payload(
+        hooks_list_response,
+        hook_command=args.hook_command,
+        hooks_json_path=args.hooks_json_path,
+    )
+    json.dump(payload, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/nix/modules/home/programs/codex/test_generate_herdr_hook_state.py
+++ b/nix/modules/home/programs/codex/test_generate_herdr_hook_state.py
@@ -1,0 +1,90 @@
+import importlib.util
+import pathlib
+
+import pytest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("generate_herdr_hook_state.py")
+SPEC = importlib.util.spec_from_file_location("generate_herdr_hook_state", MODULE_PATH)
+generate_herdr_hook_state = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(generate_herdr_hook_state)
+
+
+def hooks_list_response(*hooks):
+    return {
+        "result": {
+            "data": [
+                {
+                    "cwd": "/repo",
+                    "hooks": list(hooks),
+                    "warnings": [],
+                    "errors": [],
+                }
+            ]
+        }
+    }
+
+
+def hook(key, command, *, event_name="sessionStart", current_hash="sha256:abc"):
+    return {
+        "key": key,
+        "eventName": event_name,
+        "command": command,
+        "currentHash": current_hash,
+    }
+
+
+def test_build_payload_rekeys_user_home_hooks_path():
+    command = "/nix/store/env PATH=/nix/store/bin /nix/store/bash/bin/bash /home/me/.codex/herdr-agent-state.sh session"
+    response = hooks_list_response(
+        hook(
+            "/tmp/build-home/.codex/hooks.json:session_start:0:0",
+            "hcom codex-sessionstart",
+            current_hash="sha256:hcom",
+        ),
+        hook(
+            "/tmp/build-home/.codex/hooks.json:session_start:1:0",
+            command,
+            current_hash="sha256:herdr",
+        ),
+    )
+
+    assert generate_herdr_hook_state.build_payload(
+        response,
+        hook_command=command,
+        hooks_json_path="/home/me/.codex/hooks.json",
+    ) == {
+        "hooks": {
+            "state": {
+                "/home/me/.codex/hooks.json:session_start:1:0": {
+                    "trusted_hash": "sha256:herdr",
+                    "enabled": True,
+                }
+            }
+        }
+    }
+
+
+def test_build_payload_requires_exactly_one_herdr_hook():
+    response = hooks_list_response(
+        hook("/tmp/home/.codex/hooks.json:session_start:0:0", "hcom codex-sessionstart")
+    )
+
+    with pytest.raises(RuntimeError, match="expected exactly one"):
+        generate_herdr_hook_state.build_payload(
+            response,
+            hook_command="missing",
+            hooks_json_path="/home/me/.codex/hooks.json",
+        )
+
+
+def test_build_payload_rejects_unexpected_hook_key():
+    response = hooks_list_response(hook("bad-key", "herdr"))
+
+    with pytest.raises(RuntimeError, match="unexpected Codex hook key"):
+        generate_herdr_hook_state.build_payload(
+            response,
+            hook_command="herdr",
+            hooks_json_path="/home/me/.codex/hooks.json",
+        )

--- a/nix/modules/home/programs/herdr.nix
+++ b/nix/modules/home/programs/herdr.nix
@@ -7,6 +7,11 @@ let
     keys = {
       prefix = "ctrl+a";
     };
+
+    # Codex の native session restore はこの gate が開いている時だけ走る。
+    session = {
+      resume_agents_on_restore = true;
+    };
   };
 in
 {

--- a/nix/modules/home/programs/pi.nix
+++ b/nix/modules/home/programs/pi.nix
@@ -43,6 +43,7 @@ let
   herdrSkillLoader = pkgs.replaceVars ../../../../pi/extensions/herdr-skill-loader.ts {
     herdrSkillPath = "${pkgs.herdr-agent-plugin}/skills/herdr";
   };
+  herdrPiIntegration = pkgs.herdr-pi-integration;
 
   managedSettings = {
     defaultProvider = "openai-codex";
@@ -80,6 +81,9 @@ in
     "${pkgs.pi}/lib/node_modules/@earendil-works/pi-coding-agent";
 
   home.file.".pi/agent/extensions/herdr-skill-loader.ts".source = herdrSkillLoader;
+
+  home.file.".pi/agent/extensions/herdr-agent-state.ts".source =
+    "${herdrPiIntegration}/extensions/herdr-agent-state.ts";
 
   # Global settings are declarative. Pi may try to persist UI choices, installs,
   # or extension configuration here; those writes should fail instead of

--- a/nix/overlays/llm-agents.nix
+++ b/nix/overlays/llm-agents.nix
@@ -21,6 +21,9 @@ in
     herdr
     herdr-agent-skill
     herdr-agent-plugin
+    herdr-claude-integration
+    herdr-codex-integration
+    herdr-pi-integration
     herdr-codex-marketplace
     ;
 }

--- a/nix/packages/herdr/default.nix
+++ b/nix/packages/herdr/default.nix
@@ -151,6 +151,58 @@ rec {
         cp ${src}/SKILL.md "$out/SKILL.md"
       '';
 
+  herdr-claude-integration =
+    runCommand "herdr-claude-integration-${version}"
+      {
+        meta = {
+          description = "Herdr Claude Code native session restore integration hook";
+          homepage = "https://herdr.dev";
+          license = lib.licenses.agpl3Plus;
+          platforms = builtins.attrNames binaryAssets;
+        };
+      }
+      ''
+        home="$NIX_BUILD_TOP/home"
+        mkdir -p "$home/.claude" "$out/hooks"
+        HOME="$home" XDG_CONFIG_HOME="$home/.config" ${herdr}/bin/herdr integration install claude >/dev/null
+        install -Dm755 "$home/.claude/hooks/herdr-agent-state.sh" "$out/hooks/herdr-agent-state.sh"
+        cp "$home/.claude/settings.json" "$out/settings.json"
+      '';
+
+  herdr-codex-integration =
+    runCommand "herdr-codex-integration-${version}"
+      {
+        meta = {
+          description = "Herdr Codex native session restore integration hook";
+          homepage = "https://herdr.dev";
+          license = lib.licenses.agpl3Plus;
+          platforms = builtins.attrNames binaryAssets;
+        };
+      }
+      ''
+        home="$NIX_BUILD_TOP/home"
+        mkdir -p "$home/.codex" "$out"
+        HOME="$home" XDG_CONFIG_HOME="$home/.config" ${herdr}/bin/herdr integration install codex >/dev/null
+        install -Dm755 "$home/.codex/herdr-agent-state.sh" "$out/herdr-agent-state.sh"
+      '';
+
+  herdr-pi-integration =
+    runCommand "herdr-pi-integration-${version}"
+      {
+        meta = {
+          description = "Herdr Pi native agent state extension";
+          homepage = "https://herdr.dev";
+          license = lib.licenses.agpl3Plus;
+          platforms = builtins.attrNames binaryAssets;
+        };
+      }
+      ''
+        home="$NIX_BUILD_TOP/home"
+        mkdir -p "$home/.pi/agent/extensions" "$out/extensions"
+        HOME="$home" XDG_CONFIG_HOME="$home/.config" ${herdr}/bin/herdr integration install pi >/dev/null
+        install -Dm644 "$home/.pi/agent/extensions/herdr-agent-state.ts" "$out/extensions/herdr-agent-state.ts"
+      '';
+
   herdr-codex-marketplace =
     runCommand "herdr-codex-marketplace-${version}"
       {


### PR DESCRIPTION
## Summary
- package Herdr native integrations for Claude Code, Codex, and Pi
- install generated hooks/extensions declaratively through Home Manager
- enable Herdr session agent resume and add Codex hook-state generation tests

## Verification
- nix run .#build
- nix run .#switch
- nix run .#fmt -- --ci
- nix flake check --no-build --all-systems
- git diff --check