### PR TITLE
perf(ci): restore parallel Hestia cache probes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -527,6 +527,27 @@
         "type": "github"
       }
     },
+    "flake-parts_5": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-eval-jobs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "hcom-src": {
       "flake": false,
       "locked": {
@@ -663,6 +684,44 @@
         "type": "github"
       }
     },
+    "nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783987836,
+        "narHash": "sha256-UkRzz0meYeuSQt5rQodwfiSe1If+5JojDP7Kxk0beXM=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "aa2613fa02ca6199fe0ebf61a0f7f6d781d32a47",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.35-maintenance",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-eval-jobs": {
+      "inputs": {
+        "flake-parts": "flake-parts_5",
+        "nix": "nix",
+        "nixpkgs": "nixpkgs_3",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1786359041,
+        "narHash": "sha256-EFJnN35L7UieL8zV8qPrpqfdfzztWksY8JYuXF+mr9o=",
+        "owner": "NixOS",
+        "repo": "nix-eval-jobs",
+        "rev": "cd5c05e1072f52a11fe89b4365e10892bdb6cbda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nix-eval-jobs",
+        "type": "github"
+      }
+    },
     "nix-index-database": {
       "inputs": {
         "nixpkgs": [
@@ -754,6 +813,19 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1767026758,
+        "narHash": "sha256-OuZZ71OA/6fZePPqgVinI4QVu9j1QCt+Q9i5ZgmSGqI=",
+        "rev": "346dd96ad74dc4457a9db9de4f4f57dab2e5731d",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre918255.346dd96ad74d/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1785602060,
         "narHash": "sha256-z7D96eESRM4CPV/XtwpwFn8IDdfLAmxz6lVWrGYXvR4=",
         "owner": "nixos",
@@ -843,9 +915,10 @@
         "improve-skill": "improve-skill",
         "llm-agents": "llm-agents",
         "mozuku": "mozuku",
+        "nix-eval-jobs": "nix-eval-jobs",
         "nix-index-database": "nix-index-database",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-lib": [
           "nixpkgs"
         ],
@@ -853,7 +926,7 @@
         "pyproject-nix": "pyproject-nix",
         "rustsec-advisory-db": "rustsec-advisory-db",
         "supported-systems": "supported-systems",
-        "treefmt-nix": "treefmt-nix_2",
+        "treefmt-nix": "treefmt-nix_3",
         "uv2nix": "uv2nix"
       }
     },
@@ -937,6 +1010,27 @@
       }
     },
     "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-eval-jobs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1766000401,
+        "narHash": "sha256-+cqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "42d96e75aa56a3f70cab7e7dc4a32868db28e8fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,7 @@
     };
     llm-agents.url = "github:numtide/llm-agents.nix";
     mozuku.url = "github:t3tra-dev/MoZuKu";
+    nix-eval-jobs.url = "github:NixOS/nix-eval-jobs";
     nix-index-database = {
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/features/ci/_scripts/capture_hestia_eval.py
+++ b/modules/features/ci/_scripts/capture_hestia_eval.py
@@ -16,7 +16,7 @@ def command(arguments: list[str]) -> list[str]:
     return [
         "nix",
         "run",
-        "nixpkgs#nix-eval-jobs",
+        "nix-eval-jobs#nix-eval-jobs",
         "--inputs-from",
         ".",
         "--",
@@ -28,7 +28,7 @@ def command(arguments: list[str]) -> list[str]:
         "stalled-download-timeout",
         "30",
         "--option",
-        "download-attempts",
+        "filetransfer-retry-attempts",
         "2",
         *arguments,
     ]

--- a/modules/features/ci/_tests/test_ci_telemetry.py
+++ b/modules/features/ci/_tests/test_ci_telemetry.py
@@ -71,7 +71,7 @@ class TelemetryTests(unittest.TestCase):
             [
                 "nix",
                 "run",
-                "nixpkgs#nix-eval-jobs",
+                "nix-eval-jobs#nix-eval-jobs",
                 "--inputs-from",
                 ".",
                 "--",
@@ -83,7 +83,7 @@ class TelemetryTests(unittest.TestCase):
                 "stalled-download-timeout",
                 "30",
                 "--option",
-                "download-attempts",
+                "filetransfer-retry-attempts",
                 "2",
             ],
         )

--- a/modules/features/ci/inputs.nix
+++ b/modules/features/ci/inputs.nix
@@ -6,5 +6,6 @@
       inputs.systems.follows = "supported-systems";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };
+    nix-eval-jobs.url = "github:NixOS/nix-eval-jobs";
   };
 }


### PR DESCRIPTION
## Summary

- restore the upstream nix-eval-jobs flake input
- use the Nix 2.35 file transfer retry setting
- lock the input at the v2.35.1 release merge containing the worker re-exec fix

## Testing

- Python telemetry unit tests
- filtered workflow policy Bats tests
- check-flake-file
- ci-python-tests
- workflow-policy-tests
- nix-eval-jobs empty-expression smoke test
- three independent subagent reviews
